### PR TITLE
Add named elements to page

### DIFF
--- a/page/page.py
+++ b/page/page.py
@@ -3,7 +3,7 @@ from selenium.webdriver.common.by import By
 from page.base_element import BaseElement
 from page.step import Step
 from selenium.webdriver.chrome.options import Options
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 
 class PageBuilder:
@@ -47,7 +47,7 @@ class Page(PageBuilder):
 	def get_url(self):
 		return self.page.current_url
 
-	def element_by(self, indicator, locator):
+	def element_by(self, indicator, locator, name=''):
 		indicator = indicator.lower()
 		indicator_converter = {
 			"id": By.ID,
@@ -59,13 +59,27 @@ class Page(PageBuilder):
 			"partial link": By.PARTIAL_LINK_TEXT,
 			"tag": By.TAG_NAME
 		}
-		return BaseElement(indicator_converter.get(indicator), locator, self.page)
+		return BaseElement(indicator_converter.get(indicator), locator, self.page, name)
 
-	def collect_elements(self, collection_instructions: List[Tuple[str, str]]):
+	def element(self, name) -> BaseElement:
+		return [elem for elem in self.elements if elem.name == name][0]
+
+	def collect_anonymous_element(self, collection_instruction: Tuple[str, str]):
+		self.elements.append(
+			self.element_by(collection_instruction[0], collection_instruction[1])
+		)
+
+	def collect_named_element(self, collection_instruction: Tuple[str, str, str]):
+		self.elements.append(
+			self.element_by(collection_instruction[0], collection_instruction[1], collection_instruction[2])
+		)
+
+	def collect_elements(self, collection_instructions: List[Any]):
 		for collection_instruction in collection_instructions:
-			self.elements.append(
-				self.element_by(collection_instruction[0], collection_instruction[1])
-			)
+			if len(collection_instruction) == 2:
+				self.collect_anonymous_element(collection_instruction)
+			elif len(collection_instruction) == 3:
+				self.collect_named_element(collection_instruction)
 
 	@staticmethod
 	def do_step(*args):

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -76,3 +76,19 @@ class TestFeature(unittest.TestCase):
 		bp.do(steps)
 		english_div = helper.evaluate_element_text(bp.element_by("id", "en1"), "Hello")
 		self.assertTrue(english_div)
+
+	def test_named_elements(self):
+		self.cf.options_list.append("headless")
+		bp = page.Page(self.cf)
+		bp.go()
+		bp.collect_elements([
+			("id", "sourceNews", "input"),
+			("id", "transmitter", "button")
+		])
+		steps = [
+			step.Step("type", bp.element("input"), "Hello"),
+			step.Step("click", bp.element("button"))
+		]
+		bp.do(steps)
+		english_div = helper.evaluate_element_text(bp.element_by("id", "en1"), "Hello")
+		self.assertTrue(english_div)

--- a/tests/test_other_pages.py
+++ b/tests/test_other_pages.py
@@ -1,6 +1,6 @@
 import unittest
 from configs import config
-from page import page
+from page import page, step
 
 
 class TestOtherPages(unittest.TestCase):
@@ -29,9 +29,18 @@ class TestOtherPages(unittest.TestCase):
 		bp = page.Page(cf)
 		bp.go()
 
-		bp.element_by("xpath", "(//button[@class='btn_primary btn_inventory'])[1]").click()
-		bp.element_by("xpath", "(//button[@class='btn_primary btn_inventory'])[2]").click()
-		bp.element_by("xpath", "(//button[@class='btn_primary btn_inventory'])[3]").click()
+		bp.collect_elements([
+			("xpath", "(//button[@class='btn_primary btn_inventory'])[1]", "inv_btn1"),
+			("xpath", "(//button[@class='btn_primary btn_inventory'])[2]", "inv_btn2"),
+			("xpath", "(//button[@class='btn_primary btn_inventory'])[3]", "inv_btn3"),
+		])
+		steps = [
+			step.Step("click", bp.element("inv_btn1")),
+			step.Step("click", bp.element("inv_btn2")),
+			step.Step("click", bp.element("inv_btn3"))
+		]
+		bp.do(steps)
+
 		items_in_cart = bp.element_by("class", "shopping_cart_badge").get("innerHTML")
 		self.assertEqual(items_in_cart, "3")
 
@@ -41,10 +50,21 @@ class TestOtherPages(unittest.TestCase):
 		self.assertEqual(items_in_cart, "2")
 
 		bp.element_by("class", "checkout_button").click()
-		bp.element_by("id", "first-name").input_text("Jane")
-		bp.element_by("id", "last-name").input_text("Doe")
-		bp.element_by("id", "postal-code").input_text("12345")
-		bp.element_by("class", "cart_button").click()
+
+		bp.collect_elements([
+			("id", "first-name", "First Name"),
+			("id", "last-name", "Last Name"),
+			("id", "postal-code", "Zip"),
+			("class", "cart_button", "Cart Button")
+		])
+		steps = [
+			step.Step("type", bp.element("First Name"), "Jane"),
+			step.Step("type", bp.element("Last Name"), "Doe"),
+			step.Step("type", bp.element("Zip"), "12345"),
+			step.Step("click", bp.element("Cart Button"))
+		]
+		bp.do(steps)
+
 		bp.element_by("class", "cart_button").click()
 		checkout_complete_page = bp.element_by("class", "complete-header").get("innerHTML")
 		self.assertEqual(checkout_complete_page, "THANK YOU FOR YOUR ORDER")


### PR DESCRIPTION
Welp.. I thought adding support for steps and named elements would help refactor and make tests shorter. Nope.

But! The option is there. Perhaps this could be extended in the future. At the very lest, it's a little easier to see what's going on.