### PR TITLE
Add decorator pattern to actions

### DIFF
--- a/action/action.py
+++ b/action/action.py
@@ -1,11 +1,12 @@
 from action.element_actions import ElementActions
 from action.page_actions import PageActions
 from page_element_interface.IPageElement import *
+from action.page_actions_decorator import PageActionsDecorator
 
 
-class Action(PageActions, ElementActions):
+class Action(PageActionsDecorator, ElementActions):
     def __init__(self, driver_type='Chrome'):
         self.driver = load_driver(driver_type)
         self.action_map = None
-        PageActions.__init__(self, self.driver)
+        PageActionsDecorator.__init__(self, PageActions(self.driver))
         ElementActions.__init__(self, self.driver)

--- a/action/page_actions.py
+++ b/action/page_actions.py
@@ -1,6 +1,3 @@
-from lulu_exceptions import *
-
-
 class PageActions:
     def __init__(self, driver):
         self.driver = driver
@@ -8,28 +5,18 @@ class PageActions:
 
     def go(self, page):
         self.driver.get(page.url)
-        self.page_loaded = True
 
     def go_to(self, url):
         self.driver.get(url)
-        self.page_loaded = True
 
     def close(self):
         self.driver.close()
-        self.page_loaded = False
 
     def refresh(self):
-        self.__check_page_load()
         self.driver.refresh()
 
     def get_page_source(self):
-        self.__check_page_load()
         return self.driver.page_source
 
     def get_url(self):
-        self.__check_page_load()
         return self.driver.current_url
-
-    def __check_page_load(self):
-        if not self.page_loaded:
-            raise PageNotLoadedError("Web Driver must go to page before performing this action")

--- a/action/page_actions_decorator.py
+++ b/action/page_actions_decorator.py
@@ -1,6 +1,12 @@
 from action.page_actions import PageActions
 from lulu_exceptions import PageNotLoadedError
 
+'''
+This class contains meta-programming to decorate the
+PageActions class methods with the necessary pre and
+post processing functionality. Proceed with caution.
+'''
+
 
 class PageActionsDecorator(object):
     CHECK_PAGE_LOAD = [
@@ -15,25 +21,26 @@ class PageActionsDecorator(object):
         'close'
     ]
 
-    def __init__(self, page_actions: PageActions):
-        self.model = page_actions
+    def __init__(self, model: PageActions):
+        self.model = model
 
-    def __getattr__(self, item):
-        func = getattr(self.model, item)
-        if item in self.CHECK_PAGE_LOAD:
-            self.check_page_load(func)
-        elif item in self.SET_PAGE_LOAD:
-            self.set_page_loaded(func)
+    def __getattr__(self, func):
+        def method(*args):
+            if func in self.CHECK_PAGE_LOAD:
+                return self.check_page_load(func, *args)
+            if func in self.SET_PAGE_LOAD:
+                return self.set_page_loaded(func, *args)
+        return method
 
-    def check_page_load(self, func):
+    def check_page_load(self, func, *args):
         if not self.model.page_loaded:
             raise PageNotLoadedError("Web Driver must go to page before performing this action")
         else:
-            func()
+            return getattr(self.model, func)(*args)
 
-    def set_page_loaded(self, func):
-        func()
-        if func.__name__ == 'close':
+    def set_page_loaded(self, func, *args):
+        getattr(self.model, func)(*args)
+        if func == 'close':
             self.model.page_loaded = False
         else:
             self.model.page_loaded = True

--- a/action/page_actions_decorator.py
+++ b/action/page_actions_decorator.py
@@ -9,32 +9,35 @@ post processing functionality. Proceed with caution.
 
 
 class PageActionsDecorator(object):
-    CHECK_PAGE_LOAD = [
+    FUNCTIONS_NEEDING_PAGE_TO_BE_LOADED = [
         'refresh',
         'get_page_source',
         'get_url'
     ]
 
-    SET_PAGE_LOAD = [
+    FUNCTIONS_THAT_LOAD_THE_PAGE = [
         'go',
         'go_to',
         'close'
     ]
+
+    LOAD_WEB_DRIVER_MESSAGE = "Web Driver must go to page " \
+                              "before performing this action"
 
     def __init__(self, model: PageActions):
         self.model = model
 
     def __getattr__(self, func):
         def method(*args):
-            if func in self.CHECK_PAGE_LOAD:
+            if func in self.FUNCTIONS_NEEDING_PAGE_TO_BE_LOADED:
                 return self.check_page_load(func, *args)
-            if func in self.SET_PAGE_LOAD:
+            if func in self.FUNCTIONS_THAT_LOAD_THE_PAGE:
                 return self.set_page_loaded(func, *args)
         return method
 
     def check_page_load(self, func, *args):
         if not self.model.page_loaded:
-            raise PageNotLoadedError("Web Driver must go to page before performing this action")
+            raise PageNotLoadedError(self.LOAD_WEB_DRIVER_MESSAGE)
         else:
             return getattr(self.model, func)(*args)
 

--- a/action/page_actions_decorator.py
+++ b/action/page_actions_decorator.py
@@ -1,0 +1,39 @@
+from action.page_actions import PageActions
+from lulu_exceptions import PageNotLoadedError
+
+
+class PageActionsDecorator(object):
+    CHECK_PAGE_LOAD = [
+        'refresh',
+        'get_page_source',
+        'get_url'
+    ]
+
+    SET_PAGE_LOAD = [
+        'go',
+        'go_to',
+        'close'
+    ]
+
+    def __init__(self, page_actions: PageActions):
+        self.model = page_actions
+
+    def __getattr__(self, item):
+        func = getattr(self.model, item)
+        if item in self.CHECK_PAGE_LOAD:
+            self.check_page_load(func)
+        elif item in self.SET_PAGE_LOAD:
+            self.set_page_loaded(func)
+
+    def check_page_load(self, func):
+        if not self.model.page_loaded:
+            raise PageNotLoadedError("Web Driver must go to page before performing this action")
+        else:
+            func()
+
+    def set_page_loaded(self, func):
+        func()
+        if func.__name__ == 'close':
+            self.model.page_loaded = False
+        else:
+            self.model.page_loaded = True


### PR DESCRIPTION
The `PageActions` class has several methods that either check to see if a page has been loaded* or sets the loaded status. To adhere to the Single Responsibility Principle, I've implemented the decorator pattern by creating a `PageActionsDecorator` class. This is not to be confused with the built in Python `decorator` feature, I'm referring to the design pattern.

The decorator class takes in `PageActions` class and calls it `model`. Then, the native `__getattr__` method is overwritten; this method fires pretty much anytime a method is called on a class. The `__getattr__` method evaluates the function name and decides if it's a `PageAction` method that needs to check the page's load status before firing, or if it's a method that sets the page's load status. Depending on which, it handles the appropriate bit of page-status-manipulating-functionality and then calls the passed method by using `getattr(self.model, func)(*args)`.

This pattern needs to also be implemented to the `ElementActions` class, but as you might be able to see, that class functions very differently and will need a bit of rethinking. Since it's almost 1am on Sunday, this is something I will tackle another day.


*In this case, "loaded" essentially means the driver object has "gone to" the page in question.