### PR TITLE
Add initial stab at publishing to PyPI

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -54,18 +54,10 @@ jobs:
 
       - name: Install pypa/build
         run: |  
-          python3 -m
-          pip install
-          build
-          --user
+          python3 -m pip install build --user
       - name: Build a binary wheel and a source tarball
         run: |
-          python3 -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
-          .
+          python3 -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
This is my initial stab at publishing to PyPI with GH Actions on push.
These are slightly different than AZDO builds so let me know if something doesn't look right!

Would close issue #80 