### PR TITLE
Use properties for element type indicators

### DIFF
--- a/LuluTest/element/page_element.py
+++ b/LuluTest/element/page_element.py
@@ -5,4 +5,21 @@ class PageElement(BaseElement):
     def __init__(self, locator, name=''):
         super().__init__(name)
         self.locator = locator
-        self.is_page_element = True
+
+    @property
+    def is_page_element(self):
+      return True
+
+    @is_page_element.setter
+    def is_page_element(self, *args, **kwargs):
+      # This property cannot be changed
+      return False
+
+    @property
+    def is_alert_element(self):
+      return False
+
+    @is_alert_element.setter
+    def is_alert_element(self, *args, **kwargs):
+      # This property cannot be changed
+      return False


### PR DESCRIPTION
This is an example pull request for equivalent work that needs to be done on `AlertElement` and `BaseElement`.

This work uses Python's properties mechanism to make getters and setters for the `is_page_element` and `is_alert_element` attributes of the `PageElement` class.